### PR TITLE
add tirpc (headers in /usr/include/tirpc on, e.g., Debian 12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ endif
 
 .PHONY:	libcmlog.a
 
+# Some linux systems moved RPC related symbols to libtirpc
+# Define TIRPC in configure/CONFIG_SITE in this case
+ifeq ($(TIRPC),YES)
+  USR_INCLUDES += -I/usr/include/tirpc
+  SYS_PROD_LIBS_Linux += tirpc
+endif
+
 ifeq ($(I_WANT_CDEV),YES)
 
   CDEV_LIB      = $(CDEVLIB)


### PR DESCRIPTION
Some linux systems (e.g., Debian) moved RPC related symbols to libtirpc residing in /usr/include/tirpc.
Define TIRPC=YES in configure/CONFIG_SITE, RELEASE.local or similar to use this.
